### PR TITLE
Fix Conda Env by getting the first python interpreter from $PATH

### DIFF
--- a/pythonx/ncm2_jedi.py
+++ b/pythonx/ncm2_jedi.py
@@ -21,7 +21,7 @@ class Source(Ncm2Source):
 
         env = vim.vars['ncm2_jedi#environment']
         if not env:
-            self._env = jedi.get_default_environment()
+            self._env = jedi.create_environment(jedi._compatibility.which('python'))
         else:
             self._env = jedi.create_environment(env)
 


### PR DESCRIPTION
It is good that we can set the python interpreter path via `g:ncm2_jedi#environment`. But for people like me who regularly work with different python environments, it is not that convenient to change the variable in `init.vim` file constantly.

When a virtual env or conda env is activated, its python executable path is placed to the first position in `$PATH`. This change would pick up the first python executable from `$PATH`, when `g:ncm2_jedi#environment` is not set. As a result, it should automatically get the completion from the current virtual/conda env.

Let me know your thoughts.