### PR TITLE
jedi._compatibility.which('python') may always return the path of python2

### DIFF
--- a/pythonx/ncm2_jedi.py
+++ b/pythonx/ncm2_jedi.py
@@ -20,8 +20,11 @@ class Source(Ncm2Source):
         Ncm2Source.__init__(self, vim)
 
         env = vim.vars['ncm2_jedi#environment']
-        py2 = str(vim.vars['ncm2_jedi#python_version']) == '2'
-        py_version = 'python' if py2 else 'python3'
+        mac = vim.command("echo has('mac')")
+        py3 = str(vim.vars['ncm2_jedi#python_version']) == '3'
+        py_version = 'python'
+        if mac and py3:
+            py_version = 'python3'
 
         if not env:
             self._env = jedi.create_environment(jedi._compatibility.which(py_version))

--- a/pythonx/ncm2_jedi.py
+++ b/pythonx/ncm2_jedi.py
@@ -6,6 +6,7 @@ from ncm2 import Ncm2Source, getLogger
 import re
 import jedi
 import os
+import sys
 from jedi import settings
 
 logger = getLogger(__name__)
@@ -20,7 +21,7 @@ class Source(Ncm2Source):
         Ncm2Source.__init__(self, vim)
 
         env = vim.vars['ncm2_jedi#environment']
-        mac = vim.command("echo has('mac')")
+        mac = sys.platform.lower() == 'darwin'
         py3 = str(vim.vars['ncm2_jedi#python_version']) == '3'
         py_version = 'python'
         if mac and py3:

--- a/pythonx/ncm2_jedi.py
+++ b/pythonx/ncm2_jedi.py
@@ -20,8 +20,11 @@ class Source(Ncm2Source):
         Ncm2Source.__init__(self, vim)
 
         env = vim.vars['ncm2_jedi#environment']
+        py2 = str(vim.vars['ncm2_jedi#python_version']) == '2'
+        py_version = 'python' if py2 else 'python3'
+
         if not env:
-            self._env = jedi.create_environment(jedi._compatibility.which('python'))
+            self._env = jedi.create_environment(jedi._compatibility.which(py_version))
         else:
             self._env = jedi.create_environment(env)
 


### PR DESCRIPTION
I found the error on Mac,
```python
In [2]: jedi._compatibility.which('python')
Out[2]: '/usr/bin/python'

In [3]: jedi._compatibility.which('python3')
Out[3]: '/usr/local/bin/python3'
```