### PR TITLE
revert #16 ea0ee18 and add conda env detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,15 @@ specified by `:help g:python3_host_prog`.
 
 ### `g:ncm2_jedi#environment`
 
-When you have virtualenv, you could set this variable to the python executable
-of your virtualenv.
-
 Read
 [jedi-environments](https://jedi.readthedocs.io/en/latest/docs/api.html#environments)
 for more information.
+
+If this option is not set, ncm2-jedi uses the following priority scheme:
+
+- `$VIRTUAL_ENV` -> `jedi.get_default_environment`
+- `$CONDA_PYTHON_EXE`
+- `jedi.get_default_environment`
 
 ### `g:ncm2_jedi#settings`
 

--- a/pythonx/ncm2_jedi.py
+++ b/pythonx/ncm2_jedi.py
@@ -21,7 +21,13 @@ class Source(Ncm2Source):
 
         env = vim.vars['ncm2_jedi#environment']
         if not env:
-            self._env = jedi.create_environment(jedi._compatibility.which('python'))
+            osenv = os.environ
+            if 'VIRTUAL_ENV' not in osenv and 'CONDA_PYTHON_EXE' in osenv:
+                # if conda is active
+                self._env = jedi.create_environment(osenv['CONDA_PYTHON_EXE'])
+            else:
+                # get_default_environment handles VIRTUAL_ENV
+                self._env = jedi.get_default_environment()
         else:
             self._env = jedi.create_environment(env)
 


### PR DESCRIPTION
jedi._compatibility.which('python') always look for python exe named
'python'. Which is not good on ubuntu/debian, where python2 is
'/usr/bin/python' and python3 is '/usr/bin/python3'.

Add conda detection so that conda goes first when venv is not available.

Additional info:

close #18