### PR TITLE
use $CONDA_PREFIX instead of $CONDA_PYTHON_EXE to detect conda environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ for more information.
 If this option is not set, ncm2-jedi uses the following priority scheme:
 
 - `$VIRTUAL_ENV` -> `jedi.get_default_environment`
-- `$CONDA_PYTHON_EXE`
+- `$CONDA_PREFIX`
 - `jedi.get_default_environment`
 
 ### `g:ncm2_jedi#settings`

--- a/pythonx/ncm2_jedi.py
+++ b/pythonx/ncm2_jedi.py
@@ -22,9 +22,9 @@ class Source(Ncm2Source):
         env = vim.vars['ncm2_jedi#environment']
         if not env:
             osenv = os.environ
-            if 'VIRTUAL_ENV' not in osenv and 'CONDA_PYTHON_EXE' in osenv:
+            if 'VIRTUAL_ENV' not in osenv and 'CONDA_PREFIX' in osenv:
                 # if conda is active
-                self._env = jedi.create_environment(osenv['CONDA_PYTHON_EXE'])
+                self._env = jedi.create_environment(osenv['CONDA_PREFIX'])
             else:
                 # get_default_environment handles VIRTUAL_ENV
                 self._env = jedi.get_default_environment()


### PR DESCRIPTION
###  Why not use $CONDA_PYTHON_EXE

`$CONDA_PYTHON_EXE` is the python interpreter for conda itself (aka **base** environment), not the python interpreter in the active environment.  
from: https://github.com/conda/conda/issues/8061#issuecomment-451751989

Using `$CONDA_PYTHON_EXE` will cause `InvalidPythonEnvironment` exception here when I use ncm2-jedi under an activated environment created by myself (not the **base** environment.).
https://github.com/ncm2/ncm2-jedi/blob/485520af57aee528a3448d1f26bb7761dd915b0e/pythonx/ncm2_jedi.py#L27

### Why should use $CONDA_PREFIX 
To be honest, I can't find any exact document about  `$CONDA_PREFIX`  or `$CONDA_PREFIX`, but I found some related discussions.
Anyway, I tested it myself. Luckily it works well.

Related issues:
-  https://github.com/conda/conda/issues/2764#issue-161005495

- https://github.com/davidhalter/jedi-vim/issues/907