### PR TITLE
Temporarily signature fix for docstring generation in python2

### DIFF
--- a/pythonx/ncm2_jedi.py
+++ b/pythonx/ncm2_jedi.py
@@ -99,12 +99,20 @@ class Source(Ncm2Source):
         for complete in completions:
 
             insert = complete.complete
+            # signature error seems to occur even in the 
+            # docstring function
+            try:
+                docstring = complete.docstring()
+            except AssertionError:
+                logger.error(
+                    'signature error in docstring-generation for {}'.format(complete))
+                docstring = ''
 
             item = dict(word=ctx['base'] + insert,
                         icase=1,
                         dup=1,
                         menu=complete.description,
-                        info=complete.docstring())
+                        info=docstring)
 
             # Fix the user typed case
             if item['word'].lower() == complete.name.lower():
@@ -129,7 +137,12 @@ class Source(Ncm2Source):
 
     def render_snippet(self, item, complete, is_import):
 
-        doc = complete.docstring()
+        try:
+            doc = complete.docstring()
+        except AssertionError:
+            logger.error(
+                'signature error in docstring-generation for {}'.format(complete))
+            doc = ''
 
         # This line has performance issue
         # https://github.com/roxma/nvim-completion-manager/issues/126


### PR DESCRIPTION
The jedi library seems to have for the time being general problems with its signature class. You are explicitly catching these exceptions in your lines 73-83

```
            try:
                signatures = script.call_signatures()
                logger.info('signatures: %s', signatures)
                if len(signatures) > 0:
                    sig = signatures[-1]
                    params = [param.description for param in sig.params]
                    sig_text = sig.name + '(' + ', '.join(params) + ')'
                    logger.info("signature: %s, name: %s",
                                sig, sig.name)
            except Exception as ex:
                logger.exception("signature text failed %s", sig_text)

```

and have noticed this problem but jedi seems to have the tendency to use signatures and repeat an assertion-error regarding some binding mechanism when you call docstring on certain completions. I don't know what the error of jedi is but because of it my autocompletion regarding numpy does never work and stops ncm2-jedi completely. With python3 these signature problems are produced by some star-parsing, while in python2 some binding problems occur. By simply using try/except blocks for the dockstrings one can avoid these signature errors until these problems are fixed and contain ncm2-jedi functionality.

Maybe you can replicate the assertion error to by simply running this python code:

```
import jedi
jedi.settings.call_signatures_validity = 20
source = '''
import numpy as np
np.'''
script = jedi.Script(source, 3, len('np.'), 'example.py')
completions = script.completions()
for completion in completions:
    print(completion)
    print(completion.docstring())
```  

in my case jedi fails always with python2 as well python3