### PR TITLE
fix: resource.setrlimit only allows ints in the limits tuple

### DIFF
--- a/pythonx/ncm2_jedi.py
+++ b/pythonx/ncm2_jedi.py
@@ -220,7 +220,7 @@ try:
     import psutil
     mem = psutil.virtual_memory()
     resource.setrlimit(resource.RLIMIT_DATA,
-                       (mem.total/3, resource.RLIM_INFINITY))
+                       (int(mem.total/3), resource.RLIM_INFINITY))
 except Exception as ex:
     logger.exception('set RLIMIT_DATA failed')
 


### PR DESCRIPTION
See https://bugs.python.org/issue43101 for discussion about how support for floats was removed in 3.10.

I updated the Python version I was using for Neovim and began seeing `"[ncm2_jedi@yarp] TypeError: 'float' object cannot be interpreted as an integer"` in the status area of Neovim. With debugging enabled, I see:

```
2024-12-26 17:26:37,551 [ERROR @ ncm2_jedi.py:<module>:225] 284979 - set RLIMIT_DATA failed
Traceback (most recent call last):
  File "/home/me/.local/share/nvim/plugged/ncm2-jedi/pythonx/ncm2_jedi.py", line 222, in <module>
    resource.setrlimit(resource.RLIMIT_DATA,
TypeError: 'float' object cannot be interpreted as an integer
```

I confirmed that `mem.total/3` is the only argument passed to `setrlimit` that is a float and using this branch I no longer see the error.